### PR TITLE
Elastic security deployment manifest

### DIFF
--- a/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+++ b/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
@@ -1,0 +1,329 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: elastic-security
+  namespace: kube-system
+  labels:
+    app: elastic-security
+spec:
+  selector:
+    matchLabels:
+      app: elastic-security
+  template:
+    metadata:
+      labels:
+        app: elastic-security
+    spec:
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: elastic-security
+      hostNetwork: true
+      # 'hostPID: true' enables the Elastic Security integration to observe all process exec events on the host.
+      # Sharing the host process ID namespace gives visibility of all processes running on the same host.
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: k8smd
+          image: docker.elastic.co/endpoint/k8smd:8.4.0
+        - name: endpoint-security
+          image: docker.elastic.co/endpoint/endpoint-security:8.4.0
+          securityContext:
+            runAsUser: 0
+            privileged: true
+          volumeMounts:
+            - name: boot
+              mountPath: /boot
+            - name: debug
+              mountPath: /sys/kernel/debug
+            - name: bpf
+              mountPath: /sys/fs/bpf
+            - name: etc-passwd
+              mountPath: /mnt/host/etc/passwd
+              readOnly: true
+            - name: etc-group
+              mountPath: /mnt/host/etc/group
+              readOnly: true
+          env:
+            - name: ELASTIC_ENDPOINT_K8S
+              value: "true"
+        - name: elastic-agent
+          image: docker.elastic.co/beats/elastic-agent:8.4.0
+          env:
+            - name: ELASTIC_ENDPOINT_K8S
+              value: "true"
+            # Set to 1 for enrollment into Fleet server. If not set, Elastic Agent is run in standalone mode
+            - name: FLEET_ENROLL
+              value: "1"
+            # Set to true to communicate with Fleet with either insecure HTTP or unverified HTTPS
+            - name: FLEET_INSECURE
+              value: "true"
+            # Fleet Server URL to enroll the Elastic Agent into
+            # FLEET_URL can be found in Kibana, go to Management > Fleet > Settings
+            - name: FLEET_URL
+              value: ""
+            # Elasticsearch API key used to enroll Elastic Agents in Fleet (https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html#fleet-enrollment-tokens)
+            # If FLEET_ENROLLMENT_TOKEN is empty then KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
+            - name: FLEET_ENROLLMENT_TOKEN
+              value: ""
+            - name: KIBANA_HOST
+              value: "" #"http://kibana:5601"
+            # The basic authentication username used to connect to Kibana and retrieve a service_token to enable Fleet
+            - name: KIBANA_FLEET_USERNAME
+              value: "" #"elastic"
+            # The basic authentication password used to connect to Kibana and retrieve a service_token to enable Fleet
+            - name: KIBANA_FLEET_PASSWORD
+              value: "" #"changeme"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: proc
+              mountPath: /hostfs/proc
+              readOnly: true
+            - name: cgroup
+              mountPath: /hostfs/sys/fs/cgroup
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /hostfs/etc/kubernetes
+              readOnly: true
+            - name: var-lib
+              mountPath: /hostfs/var/lib
+              readOnly: true
+            - name: passwd
+              mountPath: /hostfs/etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /hostfs/etc/group
+              readOnly: true
+            - name: etcsysmd
+              mountPath: /hostfs/etc/systemd
+              readOnly: true
+            - name: etc-mid
+              mountPath: /etc/machine-id
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        # Needed for cloudbeat
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        # Needed for cloudbeat
+        - name: var-lib
+          hostPath:
+            path: /var/lib
+        # Needed for cloudbeat
+        - name: passwd
+          hostPath:
+            path: /etc/passwd
+        # Needed for cloudbeat
+        - name: group
+          hostPath:
+            path: /etc/group
+        # Needed for cloudbeat
+        - name: etcsysmd
+          hostPath:
+            path: /etc/systemd
+        # Mount /etc/machine-id from the host to determine host ID
+        # Needed for Elastic Security integration
+        - name: etc-mid
+          hostPath:
+            path: /etc/machine-id
+            type: File
+        - name: etc-passwd
+          hostPath:
+            path: /etc/passwd
+            type: File
+        - name: etc-group
+          hostPath:
+            path: /etc/group
+            type: File
+        - name: boot
+          hostPath:
+            path: /boot
+        - name: debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: bpf
+          hostPath:
+            path: /sys/fs/bpf
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-security
+subjects:
+  - kind: ServiceAccount
+    name: elastic-security
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: elastic-security
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: elastic-security
+subjects:
+  - kind: ServiceAccount
+    name: elastic-security
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: elastic-security
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: elastic-security-kubeadm-config
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: elastic-security
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: elastic-security-kubeadm-config
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-security
+  labels:
+    k8s-app: elastic-security
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      # Needed for cloudbeat
+      - serviceaccounts
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: [ "get", "list", "watch" ]
+  # Needed for apiserver
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+  # Needed for cloudbeat
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs: ["get", "list", "watch"]
+  # Needed for cloudbeat
+  - apiGroups: ["policy"]
+    resources:
+      - podsecuritypolicies
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elastic-security
+  # Should be the namespace where elastic-security is running
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-security
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elastic-security-kubeadm-config
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-security
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubeadm-config
+    verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-security
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-security
+---

--- a/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+++ b/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: elastic-security
+  name: elastic-agent
   namespace: kube-system
   labels:
-    app: elastic-security
+    app: elastic-agent
 spec:
   selector:
     matchLabels:
-      app: elastic-security
+      app: elastic-agent
   template:
     metadata:
       labels:
-        app: elastic-security
+        app: elastic-agent
     spec:
       # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
       # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
@@ -21,7 +21,7 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-      serviceAccountName: elastic-security
+      serviceAccountName: elastic-agent
       hostNetwork: true
       # 'hostPID: true' enables the Elastic Security integration to observe all process exec events on the host.
       # Sharing the host process ID namespace gives visibility of all processes running on the same host.
@@ -185,50 +185,50 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: elastic-security
+  name: elastic-agent
 subjects:
   - kind: ServiceAccount
-    name: elastic-security
+    name: elastic-agent
     namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: elastic-security
+  name: elastic-agent
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: kube-system
-  name: elastic-security
+  name: elastic-agent
 subjects:
   - kind: ServiceAccount
-    name: elastic-security
+    name: elastic-agent
     namespace: kube-system
 roleRef:
   kind: Role
-  name: elastic-security
+  name: elastic-agent
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: elastic-security-kubeadm-config
+  name: elastic-agent-kubeadm-config
   namespace: kube-system
 subjects:
   - kind: ServiceAccount
-    name: elastic-security
+    name: elastic-agent
     namespace: kube-system
 roleRef:
   kind: Role
-  name: elastic-security-kubeadm-config
+  name: elastic-agent-kubeadm-config
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: elastic-security
+  name: elastic-agent
   labels:
-    k8s-app: elastic-security
+    k8s-app: elastic-agent
 rules:
   - apiGroups: [""]
     resources:
@@ -292,11 +292,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: elastic-security
-  # Should be the namespace where elastic-security is running
+  name: elastic-agent
+  # Should be the namespace where elastic-agent is running
   namespace: kube-system
   labels:
-    k8s-app: elastic-security
+    k8s-app: elastic-agent
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -307,10 +307,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: elastic-security-kubeadm-config
+  name: elastic-agent-kubeadm-config
   namespace: kube-system
   labels:
-    k8s-app: elastic-security
+    k8s-app: elastic-agent
 rules:
   - apiGroups: [""]
     resources:
@@ -322,8 +322,8 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: elastic-security
+  name: elastic-agent
   namespace: kube-system
   labels:
-    k8s-app: elastic-security
+    k8s-app: elastic-agent
 ---


### PR DESCRIPTION
This PR adds the manifest for deploying elastic-security (endpoint-security, elastic-agent and k8s metadata fetcher) in a Kubernetes cluster.
This manifest has been tested on EKS and GKE.
This is based on elastic-agent's [managed deployment manifest](https://github.com/elastic/elastic-agent/blob/689aee33c923be6183267c0e45596aa8d758e6eb/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml).