### PR TITLE
Add resource limits to Elastic Defend daemonset yaml

### DIFF
--- a/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+++ b/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
@@ -30,8 +30,20 @@ spec:
       containers:
         - name: k8smd
           image: docker.elastic.co/endpoint/k8smd:8.4.0
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
         - name: endpoint-security
           image: docker.elastic.co/endpoint/endpoint-security:8.4.0
+          resources:
+            limits:
+              memory: 4000Mi
+            requests:
+              cpu: 200m
+              memory: 500Mi
           securityContext:
             runAsUser: 0
             privileged: true

--- a/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
+++ b/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
@@ -32,8 +32,20 @@ spec:
       containers:
         - name: elastic-sec-attendant
           image: docker.elastic.co/elastic-security/elastic-sec-attendant:8.5.0
+          resources:
+            limits:
+              memory: 1000Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
         - name: elastic-sec-endpoint
           image: docker.elastic.co/elastic-security/elastic-sec-endpoint:8.5.0
+          resources:
+            limits:
+              memory: 4000Mi
+            requests:
+              cpu: 200m
+              memory: 500Mi
           securityContext:
             runAsUser: 0
             privileged: true


### PR DESCRIPTION
Add default resource limits to the Elastic Defend k8s daemonset yaml templates.

Users could increase the request values for large or high usage machines, these default values should be appropriate for smaller or lower workload machines.