### PR TITLE
Add storageclasses permissions to elastic-defend template

### DIFF
--- a/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
+++ b/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
@@ -290,6 +290,10 @@ rules:
     resources:
       - podsecuritypolicies
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources:
+      - storageclasses
+    verbs: [ "get", "list", "watch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Add get, list, watch permissions for storageclasses in kubernetes managed agent manifest, which are required for the agent to monitor these resources

This ports the change from the agent kubernetes templates: https://github.com/elastic/elastic-agent/pull/1470

Closes #35 