### PR TITLE
Increase agent memory limit in k8s definitions

### DIFF
--- a/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
+++ b/releases/8.4.0/kubernetes/deploy/elastic-endpoint-security.yaml
@@ -90,10 +90,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc

--- a/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
+++ b/releases/8.5.0/kubernetes/deploy/elastic-defend.yaml
@@ -92,10 +92,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc

--- a/releases/8.6.0/kubernetes/deploy/elastic-defend.yaml
+++ b/releases/8.6.0/kubernetes/deploy/elastic-defend.yaml
@@ -104,10 +104,10 @@ spec:
             runAsUser: 0
           resources:
             limits:
-              memory: 500Mi
+              memory: 700Mi
             requests:
               cpu: 100m
-              memory: 200Mi
+              memory: 400Mi
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc


### PR DESCRIPTION
Increase the default memory limits for elastic-agent containers in the elastic-defend k8s definition yaml files.

This will help avoid problems when the container exceeds the memory limit, and as a result is killed (see https://github.com/elastic/elastic-agent/issues/2282).