### PR TITLE
Update CPU Profiling Instructions

### DIFF
--- a/CPU-Profiling-Windows.md
+++ b/CPU-Profiling-Windows.md
@@ -21,14 +21,14 @@ powershell.exe -noprofile -command "&wpr.exe -start CPU -filemode; Start-Sleep 6
 ## Process Monitor Trace 
 [Process Monitor](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon) also provides the ability to capture profiling data.  ProcMon CPU traces are less-comprehensive and lower fidelity than WPR traces, but include other context such as file, registry, network, image, and process events.
 
-### Enabling CPU Tracing
+### Enabling ProcMon CPU Tracing
 
-ProcMon does not capture CPU traces by default.  When enabled, its GUI allows a maximum of 10 samples/second.  This resolution isn't isn't useful for diagnosing some types of CPU issues.  To capture higher-fidelity (20 samples/second) traces, set the following **before launching ProcMon**:
+ProcMon does not capture CPU traces by default.  When enabled, its GUI limits resolution to 10 samples/second.  This resolution isn't isn't useful for diagnosing many types of CPU issues.  To capture higher-fidelity (20 samples/second) traces, set the following **before launching ProcMon**:
 ```
 reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 20
 ```
 
-If the system becomes unusable during high-fidelity CPU profiling, then either use this command or follow the GUI instructions below to enable 10 samples/second tracing.
+If the system becomes unusable during high-fidelity CPU profiling, then either follow the GUI instructions below or run this command **before launching ProcMon**:
 
 ```
 reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 10
@@ -52,7 +52,7 @@ If a trace was already running, start a new one by selecting **Edit** -> **Clear
 
 </details>
 
-### Capturing the Trace
+### Capturing the ProcMon Trace
 
 Now, reproduce the problematic behavior while the trace is running.  When you are done, select **All Events** and PML format in the save dialog.  The resulting PML file should compress well - please zip it.
 
@@ -64,3 +64,6 @@ Because Elastic Defend runs as an [Antimalware Protected Process Light](https://
 ```
 
  The resulting DMP file will compress well.  Please zip it.  Note you will not be able to navigate to `C:\Program Files\ELastic\Endpoint` in Windows Explorer on most systems, but you should be able to copy out the DMP file via command line.
+
+> [!TIP]  
+> PML and DMP files usually compress well.  To reduce file transfer times, please zip them.

--- a/CPU-Profiling-Windows.md
+++ b/CPU-Profiling-Windows.md
@@ -23,12 +23,12 @@ powershell.exe -noprofile -command "&wpr.exe -start CPU -filemode; Start-Sleep 6
 
 ### Enabling CPU Tracing
 
-ProcMon does not capture CPU traces by default, and its GUI allows a maximum of 10 samples/second.  This resolution isn't isn't useful for diagnosing some types of CPU issues.  To capture higher-fidelity traces, set the following **before launching ProcMon**:
+ProcMon does not capture CPU traces by default.  When enabled, its GUI allows a maximum of 10 samples/second.  This resolution isn't isn't useful for diagnosing some types of CPU issues.  To capture higher-fidelity (20 samples/second) traces, set the following **before launching ProcMon**:
 ```
 reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 20
 ```
 
-If the system becomes unusable during high-fidelity CPU profiling, then either use this command or follow the GUI instructions below.
+If the system becomes unusable during high-fidelity CPU profiling, then either use this command or follow the GUI instructions below to enable 10 samples/second tracing.
 
 ```
 reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 10

--- a/CPU-Profiling-Windows.md
+++ b/CPU-Profiling-Windows.md
@@ -23,7 +23,7 @@ powershell.exe -noprofile -command "&wpr.exe -start CPU -filemode; Start-Sleep 6
 
 ### Enabling ProcMon CPU Tracing
 
-ProcMon does not capture CPU traces by default.  When enabled, its GUI limits resolution to 10 samples/second.  This resolution isn't isn't useful for diagnosing many types of CPU issues.  To capture higher-fidelity (20 samples/second) traces, set the following **before launching ProcMon**:
+ProcMon does not capture CPU traces by default.  When enabled, its GUI limits resolution to 10 samples/second.  This resolution isn't useful for diagnosing many types of CPU issues.  To capture higher-fidelity (20 samples/second) traces, set the following **before launching ProcMon**:
 ```
 reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 20
 ```

--- a/CPU-Profiling-Windows.md
+++ b/CPU-Profiling-Windows.md
@@ -21,7 +21,24 @@ powershell.exe -noprofile -command "&wpr.exe -start CPU -filemode; Start-Sleep 6
 ## Process Monitor Trace 
 [Process Monitor](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon) also provides the ability to capture profiling data.  ProcMon CPU traces are less-comprehensive and lower fidelity than WPR traces, but include other context such as file, registry, network, image, and process events.
 
-ProcMon CPU traces are not enabled by default.  To enable profiling data capture, Select **Options** -> **Profiling Events**
+### Enabling CPU Tracing
+
+ProcMon does not capture CPU traces by default, and its GUI allows a maximum of 10 samples/second.  This resolution isn't isn't useful for diagnosing some types of CPU issues.  To capture higher-fidelity traces, set the following **before launching ProcMon**:
+```
+reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 20
+```
+
+If the system becomes unusable during high-fidelity CPU profiling, then either use this command or follow the GUI instructions below.
+
+```
+reg.exe add "HKCU\Software\SysInternals\Process Monitor" /f /v Profiling /t REG_DWORD /d 10
+```
+
+<details>
+  
+<summary>Configure Low-Fidelity CPU Profiling via GUI</summary>
+
+To enable profiling 10 samples/sec data capture, Select **Options** -> **Profiling Events**
 
 ![image](https://github.com/user-attachments/assets/8d79cab5-a425-4fe8-8016-107b76bfa3c0)
 
@@ -32,6 +49,10 @@ Then check **Generate thread profiling events** and select **Every 100 milliseco
 If a trace was already running, start a new one by selecting **Edit** -> **Clear Display**
 
 ![image](https://github.com/user-attachments/assets/2155763c-c447-4ea6-9791-b58ff1a46b58)
+
+</details>
+
+### Capturing the Trace
 
 Now, reproduce the problematic behavior while the trace is running.  When you are done, select **All Events** and PML format in the save dialog.  The resulting PML file should compress well - please zip it.
 


### PR DESCRIPTION
Looking at customer PMLs for SDH, I can see ProcMon's default 100ms resolution cap is limiting our ability to see where Endpoint is actually spending CPU.  This PR updates the instructions to guide customers towards setting a 50ms (20/sec) sampling interval, which seems to be a sweet spot between resolution and system stability.  My experiments with higher values have resulted in hung systems.